### PR TITLE
Decouple libConfiguration from libCommon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,6 @@ O2_GENERATE_EXECUTABLE(
         EXE_NAME configuration-copy
         SOURCES src/CommandLineUtilities/Copy.cxx
         MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-        BUCKET_NAME configuration_app_bucket
         BUCKET_NAME ${APP_BUCKET_NAME}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ endif()
 
 if(PROTOBUF_FOUND AND GRPC_FOUND AND RAPIDJSON_FOUND AND PPCONSUL_FOUND)
     # Add ETCD v3 backend if the protocol buffer dependency was found
-    set(BUCKET_NAME_CONFIG configuration_bucket_with_rapidjson_etcd3)
+    set(BUCKET_NAME_SUFFIX _with_rapidjson_etcd3)
     include_directories(src/Backends/EtcdV3/proto/googleapis)
     list(APPEND SRCS
             src/Backends/EtcdV3/EtcdV3Backend.cxx
@@ -146,37 +146,39 @@ if(PROTOBUF_FOUND AND GRPC_FOUND AND RAPIDJSON_FOUND AND PPCONSUL_FOUND)
             )
     message(STATUS "json file backend enabled")
 else ()
-    set(BUCKET_NAME_CONFIG configuration_bucket)
+  set(BUCKET_NAME_SUFFIX "")
     message(STATUS "json file, etcd v2, etcd v3, consul dependencies missing, compilation skipped for corresponding classes")
 endif ()
-set(BUCKET_NAME ${BUCKET_NAME_CONFIG})
+set(BUCKET_NAME configuration_bucket${BUCKET_NAME_SUFFIX})
+set(APP_BUCKET_NAME configuration_app_bucket${BUCKET_NAME_SUFFIX})
 
 O2_GENERATE_LIBRARY()
 
 # todo we repeat ourselves because the above macro dares deleting the variables we pass to it.
 set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME ${BUCKET_NAME_CONFIG})
 
 message(STATUS LIBRARY_NAME: ${LIBRARY_NAME})
 message(STATUS BUCKET_NAME: ${BUCKET_NAME})
+message(STATUS APP_BUCKET_NAME: ${APP_BUCKET_NAME})
 
 O2_GENERATE_EXECUTABLE(
         EXE_NAME configuration-put
         SOURCES src/CommandLineUtilities/Put.cxx
         MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-        BUCKET_NAME ${BUCKET_NAME}
+        BUCKET_NAME ${APP_BUCKET_NAME}
 )
 O2_GENERATE_EXECUTABLE(
         EXE_NAME configuration-get
         SOURCES src/CommandLineUtilities/Get.cxx
         MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-        BUCKET_NAME ${BUCKET_NAME}
+        BUCKET_NAME ${APP_BUCKET_NAME}
 )
 O2_GENERATE_EXECUTABLE(
         EXE_NAME configuration-copy
         SOURCES src/CommandLineUtilities/Copy.cxx
         MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-        BUCKET_NAME ${BUCKET_NAME}
+        BUCKET_NAME configuration_app_bucket
+        BUCKET_NAME ${APP_BUCKET_NAME}
 )
 
 enable_testing()
@@ -189,7 +191,7 @@ set(TEST_SRCS
 
 O2_GENERATE_TESTS(
         MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-        BUCKET_NAME ${BUCKET_NAME}
+        BUCKET_NAME ${APP_BUCKET_NAME}
         TEST_SRCS ${TEST_SRCS}
 )
 

--- a/cmake/ConfigurationDependencies.cmake
+++ b/cmake/ConfigurationDependencies.cmake
@@ -70,15 +70,14 @@ o2_define_bucket(
     DEPENDENCIES
     ${CURL_LIBRARIES}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${Common_LIBRARIES}
     ${MYSQL_LIBRARIES}
 
     SYSTEMINCLUDE_DIRECTORIES
     ${Boost_INCLUDE_DIR}
     ${CURL_INCLUDE_DIRS}
-    ${Common_INCLUDE_DIRS}
     ${MYSQL_INCLUDE_DIRS}
 )
+
 
 # This bucket does not inherit from configuration_bucket because we want to enforce a certain order of includes.
 o2_define_bucket(
@@ -105,3 +104,26 @@ o2_define_bucket(
     ${MYSQL_INCLUDE_DIRS}
 )
 
+o2_define_bucket(
+    NAME
+    configuration_app_bucket
+
+    DEPENDENCIES
+    configuration_bucket
+    ${Common_LIBRARIES}
+
+    SYSTEMINCLUDE_DIRECTORIES
+    ${Common_INCLUDE_DIRS}
+  )
+
+o2_define_bucket(
+    NAME
+    configuration_app_bucket_with_rapidjson_etcd3
+
+    DEPENDENCIES
+    configuration_bucket_with_rapidjson_etcd3
+    ${Common_LIBRARIES}
+
+    SYSTEMINCLUDE_DIRECTORIES
+    ${Common_INCLUDE_DIRS}
+  )

--- a/src/Backends/MySql/MySqlBackend.cxx
+++ b/src/Backends/MySql/MySqlBackend.cxx
@@ -8,7 +8,6 @@
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 #include <mysql/mysql.h>
-#include <Common/GuardFunction.h>
 
 using namespace std::string_literals;
 


### PR DESCRIPTION
The dependency of libConfiguration to libCommon is not actually required
as the only usage of libCommon is done by helper tools, not
by libConfiguration itself. This takes that into account and
decouples the two libraries. This is required by the fact that
currently DataSampling has a dependency on libConfiguration but not
libCommon and so this simplifies therefore integration.