### PR TITLE
Allow deeper structure in INI files

### DIFF
--- a/src/Backends/Ini/IniBackend.cxx
+++ b/src/Backends/Ini/IniBackend.cxx
@@ -57,6 +57,22 @@ IniBackend::IniBackend(const std::string& filePath)
     : mFilePath(filePath)
 {
   loadConfigFile(filePath, mPropertyTree);
+  boost::property_tree::ptree finalTree;
+  std::function<void(const boost::property_tree::ptree&, std::string)> parseTree;
+  parseTree = [&finalTree, &parseTree](const boost::property_tree::ptree& pt, std::string key) {
+    std::string nkey;
+    if (!key.empty()) {
+      if (pt.data().size() != 0) {
+        finalTree.put(boost::property_tree::ptree::path_type(key, '/'), pt.data());
+      }
+      nkey = key + "/";
+    }
+    for (auto const &it: pt) {
+      parseTree(it.second, nkey + it.first);
+    }
+  };
+  parseTree(mPropertyTree, "");
+  mPropertyTree = finalTree;
 }
 
 void IniBackend::putString(const std::string&, const std::string&)

--- a/test/TestIni.cxx
+++ b/test/TestIni.cxx
@@ -42,7 +42,10 @@ BOOST_AUTO_TEST_CASE(IniFileTest)
         "[section]\n"
         "key_int=123\n"
         "key_float=4.56\n"
-        "key_string=hello\n";
+        "key_string=hello\n"
+        "[root_section/child_section]\n"
+        "key_string=world\n"
+        "key_int=321\n";
   }
 
   // Get file configuration interface from factory
@@ -62,6 +65,8 @@ BOOST_AUTO_TEST_CASE(IniFileTest)
   BOOST_CHECK(conf->get<int>("section/key_int").get_value_or(-1) == 123);
   BOOST_CHECK(conf->get<double>("section/key_float").get_value_or(-1.0) == 4.56);
   BOOST_CHECK(conf->get<std::string>("section/key_string").get_value_or("") == "hello");
+  BOOST_CHECK(conf->get<std::string>("root_section/child_section/key_string").get_value_or("") == "world");
+  BOOST_CHECK(conf->get<int>("root_section/child_section/key_int").get_value_or(-1) == 321);
 
 
   // Check with custom separator


### PR DESCRIPTION
This is workaround I came up on, it rewrites ptree and includes `/` provided in INI sections.
https://alice.its.cern.ch/jira/projects/OCONF/issues/OCONF-93