### PR TITLE
Keep boost 1.70.0 happy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 ####################################
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.5.2 FATAL_ERROR)
+SET(BUILD_SHARED_LIBS ON)
 
 # Set cmake policy by version: https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html
 if(${CMAKE_VERSION} VERSION_LESS 3.12)


### PR DESCRIPTION
This seems to be required because boost 1.70.0 will
otherwise offer a static version of unit_test_framework,
which conflicts with the fact we set BOOST_TEST_DYN_LINK explicitly, resulting in undefined symbols.