### PR TITLE
Don't add a separator to an empty prefix

### DIFF
--- a/src/Backends/BackendBase.h
+++ b/src/Backends/BackendBase.h
@@ -49,7 +49,7 @@ class BackendBase: public ConfigurationInterface, public boost::noncopyable
     /// \param A path prefix
     virtual void setPrefix(const std::string& prefix) override
     {
-      mPrefix = prefix + getSeparator();
+      mPrefix = prefix.empty() ? "" : prefix + getSeparator();
     }
 
   protected:


### PR DESCRIPTION
Doing `config->setPrefix("");` would result in having a prefix "." instead of "".