### PR TITLE
Fix broken RPATH generation (O2-1125)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,18 +157,11 @@ target_link_libraries(configuration-convert
 ####################################
 
 include(GNUInstallDirs)
+include(O2DefineOutputPaths)
+include(O2DefineRPATH)
 
-# Build targets with install rpath on Mac to dramatically speed up installation
-# https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  if("${isSystemDir}" STREQUAL "-1")
-    set(CMAKE_INSTALL_RPATH "@loader_path/../lib")
-  endif()
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-endif()
-unset(isSystemDir)
+o2_define_output_paths()
+o2_define_rpath()
 
 # Install library
 install(TARGETS Configuration configuration-convert

--- a/cmake/O2DefineOutputPaths.cmake
+++ b/cmake/O2DefineOutputPaths.cmake
@@ -1,0 +1,36 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+include_guard()
+
+function(o2_define_output_paths)
+
+  # Set CMAKE_INSTALL_LIBDIR explicitly to lib (to avoid lib64 on CC7)
+  set(CMAKE_INSTALL_LIBDIR lib PARENT_SCOPE)
+
+  include(GNUInstallDirs)
+
+  if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY
+        ${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_BINDIR}
+        PARENT_SCOPE)
+  endif()
+  if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY
+        ${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_LIBDIR}
+        PARENT_SCOPE)
+  endif()
+  if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY
+        ${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_LIBDIR}
+        PARENT_SCOPE)
+  endif()
+
+endfunction()

--- a/cmake/O2DefineRPATH.cmake
+++ b/cmake/O2DefineRPATH.cmake
@@ -1,0 +1,46 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+include_guard()
+
+include(GNUInstallDirs)
+
+#
+# o2_define_rpath defines our RPATH settings
+#
+function(o2_define_rpath)
+
+  if(APPLE)
+    set(basePoint @loader_path)
+  else()
+    set(basePoint $ORIGIN)
+  endif()
+
+  # use, i.e. do not skip, the full RPATH in the _build_ tree
+  set(CMAKE_SKIP_BUILD_RPATH FALSE PARENT_SCOPE)
+  # when building, do not use the install RPATH already (will only be used when
+  # actually installing), unless we are on a Mac (where the install is otherwise
+  # pretty slow)
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE PARENT_SCOPE)
+  if(APPLE)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE PARENT_SCOPE)
+  endif()
+
+  # add to the install RPATH the (automatically determined) parts of the RPATH
+  # that point to directories outside the build tree
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE PARENT_SCOPE)
+
+  # specify libraries directory relative to binaries one.
+  file(RELATIVE_PATH relDir ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+       ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+
+  set(CMAKE_INSTALL_RPATH ${basePoint} ${basePoint}/${relDir} PARENT_SCOPE)
+
+endfunction()


### PR DESCRIPTION
Apparently the RPATH information is not correctly generated
for all the FLP projects, resulting in libraries which need
DYLD_LIBRARY_PATH to be setup in order to be loaded correctly.
This does not happen for other projects, most notably O2, which
has the following fix added.