### PR TITLE
Fix prefix setting for consul backends

### DIFF
--- a/src/Backends/Consul/ConsulBackend.cxx
+++ b/src/Backends/Consul/ConsulBackend.cxx
@@ -87,7 +87,7 @@ void ConsulBackend::putRecursive(const std::string& path, const boost::property_
 
 boost::optional<std::string> ConsulBackend::getString(const std::string& path)
 {
-  auto item = mStorage.item(replaceDefaultWithSlash(addPrefix(path)),
+  auto item = mStorage.item(replaceDefaultWithSlash(addConsulPrefix(path)),
       ppconsul::kw::consistency = ppconsul::Consistency::Stale);
   if (item.valid()) {
     return std::move(item.value);
@@ -98,7 +98,7 @@ boost::optional<std::string> ConsulBackend::getString(const std::string& path)
 
 boost::property_tree::ptree ConsulBackend::getRecursive(const std::string& path)
 {
-  auto requestKey = replaceDefaultWithSlash(addPrefix(path));
+  auto requestKey = replaceDefaultWithSlash(addConsulPrefix(path));
   auto items = mStorage.items(requestKey, ppconsul::kw::consistency = ppconsul::Consistency::Stale);
   if (items.size() == 0) {
     return {};
@@ -142,7 +142,7 @@ boost::property_tree::ptree ConsulBackend::getRecursive(const std::string& path)
 
 KeyValueMap ConsulBackend::getRecursiveMap(const std::string& path)
 {
-  auto requestKey = replaceDefaultWithSlash(addPrefix(path));
+  auto requestKey = replaceDefaultWithSlash(addConsulPrefix(path));
   auto items = mStorage.items(requestKey, ppconsul::kw::consistency = ppconsul::Consistency::Stale);
   KeyValueMap map;
   for (const auto& item : items) {

--- a/src/Backends/Consul/ConsulBackend.h
+++ b/src/Backends/Consul/ConsulBackend.h
@@ -43,7 +43,21 @@ class ConsulBackend final : public BackendBase
     virtual KeyValueMap getRecursiveMap(const std::string&) override;
     virtual boost::property_tree::ptree getRecursive(const std::string& path) override;
 
+    void setBasePrefix(const std::string& path)
+    {
+      mBasePrefix = path;
+    }
+
   private:
+    /// Prepends path with the consul and current prefix
+    /// A full consul key is needed by the ppconsul invocation
+    /// \param path A path
+    /// \return Provided path with prepended prefix, i.e. full consul key
+    auto addConsulPrefix(const std::string& path)
+    {
+      return mBasePrefix.empty() ? addPrefix(path) : mBasePrefix + getSeparator() + addPrefix(path);
+    }
+
     /// Replaces DEFAULT_SEPARATOR with '/', this is required by ppconsul
     /// \param path A path with DEFAULT_SEPARATOR
     /// \retrun A path with '/' separator
@@ -59,6 +73,9 @@ class ConsulBackend final : public BackendBase
 
     /// Key-value object
     ppconsul::kv::Kv mStorage;
+
+    /// Base Consul key
+    std::string mBasePrefix;
 };
 
 } // namespace backends

--- a/src/ConfigurationFactory.cxx
+++ b/src/ConfigurationFactory.cxx
@@ -55,7 +55,7 @@ auto getConsul(const http::url& uri) -> UniqueConfiguration
 {
   auto consul = std::make_unique<backends::ConsulBackend>(uri.host, uri.port);
   if (!uri.path.empty()) {
-    consul->setPrefix(uri.path.substr(1));
+    consul->setBasePrefix(uri.path.substr(1));
   }
   return consul;
 }

--- a/test/TestConsul.cxx
+++ b/test/TestConsul.cxx
@@ -68,16 +68,19 @@ BOOST_AUTO_TEST_CASE(ConsulPrefix)
 {
   auto conf = ConfigurationFactory::getConfiguration("consul://" + CONSUL_ENDPOINT);
   conf->setPrefix("configLibTest");
-  auto subTree = conf->getRecursive("configLibTest");
-  BOOST_CHECK_EQUAL(subTree.get<int>("one", 1), 1);
+  auto subTree = conf->getRecursive("tree");
+  BOOST_CHECK_EQUAL(subTree.get<int>("one"), 1);
   BOOST_CHECK_EQUAL(conf->get<std::string>("my_string"), "configuration");
   BOOST_CHECK_EQUAL(conf->get<int>("tree.one"), 1);
+}
 
+BOOST_AUTO_TEST_CASE(ConsulPrefix2)
+{
   auto confPath = ConfigurationFactory::getConfiguration("consul://" + CONSUL_ENDPOINT + "/configLibTest");
-  auto subTreePath = confPath->getRecursive("configLibTest");
-  BOOST_CHECK_EQUAL(subTreePath.get<int>("one", 1), 1);
-  BOOST_CHECK_EQUAL(confPath->get<std::string>("my_string"), "configuration");
-  BOOST_CHECK_EQUAL(confPath->get<int>("tree.one"), 1);
+  auto subTreePath = confPath->getRecursive("tree");
+  BOOST_CHECK_EQUAL(subTreePath.get<int>("one"), 1);
+  confPath->setPrefix("tree");
+  BOOST_CHECK_EQUAL(confPath->get<int>("one"), 1);
 }
 
 BOOST_AUTO_TEST_CASE(ConsulArray)


### PR DESCRIPTION
Using the configuration library with a consul backend for the following sequence was unsuccessful
```
getRecursive()
setPrefix()
getString()
```

Getting a recursive tree, using the `setPrefix()` command overwrites the base consul key. It seems having the full key is necesary for the ppconsul invocation for a successful `getString()` execution (contrary to the interfaces for ini and json sources).

Proposed solution: Hold an mBasePrefix variable for the Consul backend and work with prefixes on top of that. Validated with the current ReadoutCard implementation, see [here](https://github.com/AliceO2Group/ReadoutCard/blob/master/src/CardConfigurator.cxx#L101).