### PR TITLE
[OCONF-388] Consul getRecursive parses INI and JSON strings

### DIFF
--- a/src/Backends/Consul/ConsulBackend.cxx
+++ b/src/Backends/Consul/ConsulBackend.cxx
@@ -14,6 +14,8 @@
 /// \author Pascal Boeschoten, CERN
 
 #include "ConsulBackend.h"
+#include <boost/property_tree/ini_parser.hpp>
+#include <boost/property_tree/json_parser.hpp>
 
 namespace o2
 {
@@ -78,6 +80,16 @@ boost::property_tree::ptree ConsulBackend::getRecursive(const std::string& path)
     return {};
   }
   boost::property_tree::ptree tree;
+  if (items.size() == 1 && !requestKey.compare(items.front().key)) {
+    std::stringstream ss;
+    ss << items.front().value;
+    if (items.front().value.front() == '{') {
+      boost::property_tree::read_json(ss, tree);
+    } else if (items.front().value.front() == '[') {
+      boost::property_tree::ini_parser::read_ini(ss, tree);
+    }
+    return tree;
+  }
   for (const auto& item : items) {
     if (!item.value.empty()) {
       tree.put(replaceSlashWithDefault(stripRequestKey(requestKey, item.key)), std::move(item.value));

--- a/src/Backends/Consul/ConsulBackend.h
+++ b/src/Backends/Consul/ConsulBackend.h
@@ -52,9 +52,13 @@ class ConsulBackend final : public BackendBase
     /// A full consul key is needed by the ppconsul invocation
     /// \param path A path
     /// \return Provided path with prepended prefix, i.e. full consul key
-    auto addConsulPrefix(const std::string& path)
+    std::string addConsulPrefix(const std::string& path)
     {
-      return mBasePrefix.empty() ? addPrefix(path) : mBasePrefix + getSeparator() + addPrefix(path);
+      if (path.empty()) {
+        return mBasePrefix.empty() ? "" : mBasePrefix;
+      } else {
+        return mBasePrefix.empty() ? addPrefix(path) : mBasePrefix + getSeparator() + addPrefix(path);
+      }
     }
 
     /// Replaces DEFAULT_SEPARATOR with '/', this is required by ppconsul

--- a/test/TestConsul.cxx
+++ b/test/TestConsul.cxx
@@ -119,6 +119,16 @@ BOOST_AUTO_TEST_CASE(ConsulIni)
   BOOST_CHECK_EQUAL(ini.get<std::string>("section.key_string"), "hello");
 }
 
+BOOST_AUTO_TEST_CASE(ConsulJsonPrefix)
+{
+  auto conf = ConfigurationFactory::getConfiguration("consul://" + CONSUL_ENDPOINT + "/configLibTest.json");
+  auto json = conf->getRecursive("");
+
+  BOOST_CHECK_EQUAL(json.get<std::string>("configuration_library.id"), "file");
+  BOOST_CHECK_EQUAL(json.get<std::string>("configuration_library.popup.menuitem.one.onclick"), "CreateNewDoc");
+  BOOST_CHECK_EQUAL(json.get<int>("configuration_library.popup.menuitem.one.value"), 123);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_CASE(Dummy)

--- a/test/TestIni.cxx
+++ b/test/TestIni.cxx
@@ -38,11 +38,10 @@ BOOST_AUTO_TEST_CASE(IniFileTest)
   {
     std::ofstream stream(TEMP_FILE);
     stream <<
-      "key=value\n"
-        "[section]\n"
-        "key_int=123\n"
-        "key_float=4.56\n"
-        "key_string=hello\n";
+      "[section]\n"
+      "key_int=123\n"
+      "key_float=4.56\n"
+      "key_string=hello\n";
   }
 
   // Get file configuration interface from factory
@@ -61,7 +60,6 @@ BOOST_AUTO_TEST_CASE(IniFileTest)
   BOOST_CHECK_THROW(conf->get<int>("this_is.a_bad.key"), std::runtime_error);
 
   // Check with default separator
-  BOOST_CHECK(conf->get<std::string>("key") == "value");
   BOOST_CHECK(conf->get<int>("section.key_int") == 123);
   BOOST_CHECK(conf->get<double>("section.key_float") == 4.56);
   BOOST_CHECK(conf->get<std::string>("section.key_string") == "hello");
@@ -71,7 +69,6 @@ BOOST_AUTO_TEST_CASE(IniFileTestPtreeGetTotal)
 {
   auto conf = ConfigurationFactory::getConfiguration("ini:/" + TEMP_FILE);
   auto tree = conf->getRecursive();
-  BOOST_CHECK_EQUAL(tree.get<std::string>("key"), "value");
   BOOST_CHECK_EQUAL(tree.get<double>("section.key_float"), 4.56);
   BOOST_CHECK_EQUAL(tree.get<std::string>("section.key_string"), "hello");
 }


### PR DESCRIPTION
TODO:
- [ ] INI/JSON detection
- [ ] Test with Readout, ReadoutCard and QC
- [ ] Make sure that moving from file to Consul backend does not require code changes
- [ ] Keep it as it is vs add internal ptree to Consul backend for parsed INI/JSON (this means limitation to 1 `getRecursive`)