### PR TITLE
[OCONF-440] Drop Consul arrays and add Consul INI and JSON backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ std::unique_ptr<ConfigurationInterface> = ConfigurationFactory::getConfiguration
 
 The URI is constructed based on the table below:
 
-| Backend name | URI backned  | Host  | Port | Path  | Dependency |
-| ------------ |:------------:|:-----:|:----:|:-----:|-----------:|
-| INI file     | `ini://`     | -     | - | File path | - |
-| JSON file    | `json://`    | -     | - | File path | - |
-| Consul       | `consul://`  | Server's hostname | Server's port | - | [ppconsul](https://github.com/oliora/ppconsul) |
-| String       | `str://`     | -     | - | List of `;` separated key-values; `.` is used to define levels (as in `ptree`) | - |
-
+| Backend name | URI backned      | Host  | Port | Path  | Dependency |
+| ------------ |:----------------:|:-----:|:----:|:-----:|-----------:|
+| INI file     | `ini://`         | -     | - | File path | - |
+| JSON file    | `json://`        | -     | - | File path | - |
+| Consul       | `consul://`      | Server's hostname | Server's port | - | [ppconsul](https://github.com/oliora/ppconsul) |
+| Consul JSON  | `consul-json://` | Consul host | Consul port | Path to a value with JSON data | [ppconsul](https://github.com/oliora/ppconsul) |
+| Consul INI   | `consul-ini://`  | Consul host | Consul port | Path to a value with INI data | [ppconsul](https://github.com/oliora/ppconsul) |
+| String       | `str://`         | -     | - | List of `;` separated key-values; `.` is used to define levels (as in `ptree`) | - |
 
 
 ## Getting values

--- a/src/Backends/Consul/ConsulBackend.cxx
+++ b/src/Backends/Consul/ConsulBackend.cxx
@@ -59,32 +59,6 @@ void ConsulBackend::putString(const std::string& path, const std::string& value)
   mStorage.set(replaceDefaultWithSlash(addPrefix(path)), value);
 }
 
-void ConsulBackend::putRecursive(const std::string& path, const boost::property_tree::ptree& tree)
-{
-  using boost::property_tree::ptree;
-  std::function<void(const ptree&, std::string)> parse = [&](const ptree& pt, std::string key) {
-     if (!key.empty()) {
-      if (!pt.data().empty()) {
-        putString(path + getSeparator() + key, pt.data());
-      }
-      key += getSeparator();
-    }
-    int index = 0;
-    for (ptree::const_iterator it = pt.begin(); it != pt.end(); it++) {
-      if (it->first.empty()) {
-        if (it == pt.begin()) {
-          key.pop_back();
-          key = key + "[]" + getSeparator();
-        }
-        parse(it->second, key + std::to_string(index++));
-      } else {
-        parse(it->second, key + it->first);
-      }
-    }
-  };
-  parse(tree, "");
-}
-
 boost::optional<std::string> ConsulBackend::getString(const std::string& path)
 {
   auto item = mStorage.item(replaceDefaultWithSlash(addConsulPrefix(path)),
@@ -100,43 +74,10 @@ boost::property_tree::ptree ConsulBackend::getRecursive(const std::string& path)
 {
   auto requestKey = replaceDefaultWithSlash(addConsulPrefix(path));
   auto items = mStorage.items(requestKey, ppconsul::kw::consistency = ppconsul::Consistency::Stale);
-  if (items.size() == 0) {
-    return {};
-  }
-  bool isArray = false;
   boost::property_tree::ptree tree;
   for (const auto& item : items) {
-    if (!item.value.empty()) {
-      // detect whether this is array
-      if (item.key.substr(requestKey.size()).substr(0, 2) == "[]") {
-        tree.put(replaceSlashWithDefault(stripRequestKey(requestKey + "[]", item.key)), std::move(item.value));
-        isArray = true;
-      } else {
-        tree.put(replaceSlashWithDefault(stripRequestKey(requestKey, item.key)), std::move(item.value));
-      }
-    }
+    tree.put(replaceSlashWithDefault(stripRequestKey(requestKey, item.key)), std::move(item.value));
   }
-
-  using boost::property_tree::ptree;
-  std::function<void(ptree&, bool)> parse = [&](ptree& node, bool replace) {
-    if (replace) {
-      ptree children;
-      for (auto& it: node) {
-        children.push_back(std::make_pair("", it.second));
-      }
-      node.swap(children);
-    }
-    for (ptree::iterator it = node.begin(); it != node.end(); it++) {
-      if (it->first.back() == ']') {
-        parse(it->second, true);
-        node.insert(it, make_pair(it->first.substr(0, it->first.length() - 2), it->second));
-        node.erase(it);
-      } else {
-        parse(it->second, false);
-      }
-    }
-  };
-  parse(tree, isArray);
   return tree;
 }
 
@@ -157,4 +98,3 @@ KeyValueMap ConsulBackend::getRecursiveMap(const std::string& path)
 } // namespace backends
 } // namespace configuration
 } // namespace o2
-

--- a/src/Backends/Consul/ConsulBackend.h
+++ b/src/Backends/Consul/ConsulBackend.h
@@ -38,7 +38,6 @@ class ConsulBackend final : public BackendBase
     /// Default destructor
     virtual ~ConsulBackend() = default;
     virtual void putString(const std::string& path, const std::string& value) override;
-    virtual void putRecursive(const std::string& path, const boost::property_tree::ptree& tree) override;
     virtual boost::optional<std::string> getString(const std::string& path) override;
     virtual KeyValueMap getRecursiveMap(const std::string&) override;
     virtual boost::property_tree::ptree getRecursive(const std::string& path) override;

--- a/src/Backends/Ini/IniBackend.cxx
+++ b/src/Backends/Ini/IniBackend.cxx
@@ -36,37 +36,35 @@ namespace backends
 ///              file formats):
 ///                 .ini, .cfg    see example.cfg
 /// \exception   Throws a <std::string> exception on error.
-void loadConfigFile(const std::string& filePath,
-                    boost::property_tree::ptree& pt)
+void loadConfigFile(const std::string& file, boost::property_tree::ptree& pt, bool isStream)
 {
-  if (filePath.length() == 0) {
+  if (file.length() == 0) {
     throw std::runtime_error("Invalid argument");
   }
-
-  // INI file
-  for (auto suffix : {".ini", ".cfg"}) {
-    if (boost::algorithm::ends_with(filePath, suffix)) {
-      try {
-        boost::property_tree::ini_parser::read_ini(filePath, pt);
-      } catch (const boost::property_tree::ini_parser::ini_parser_error& perr) {
-        std::stringstream ss;
-        if (perr.line()) {
-          ss << perr.message() << " in " << perr.filename() << " line "
-             << perr.line();
-        } else {
-          ss << perr.message() << " " << perr.filename();
-        }
-        throw std::runtime_error(ss.str());
-      }
-      return;
+  try {
+    if (isStream) {
+      std::istringstream ss;
+      ss.str(file);
+      boost::property_tree::ini_parser::read_ini(ss, pt);
+    } else {
+      boost::property_tree::ini_parser::read_ini(file, pt);
     }
+  } catch (const boost::property_tree::ini_parser::ini_parser_error& perr) {
+    std::stringstream ss;
+    if (perr.line()) {
+      ss << perr.message() << " in " << perr.filename() << " line "
+         << perr.line();
+    } else {
+      ss << perr.message() << " " << perr.filename();
+    }
+    throw std::runtime_error(ss.str());
   }
-  throw std::runtime_error("Invalid type in file name");
+  return;
 }
 
-IniBackend::IniBackend(const std::string& filePath)
+IniBackend::IniBackend(const std::string& file, bool isStream)
 {
-  loadConfigFile(filePath, mPropertyTree);
+  loadConfigFile(file, mPropertyTree, isStream);
 }
 
 void IniBackend::putString(const std::string&, const std::string&)

--- a/src/Backends/Ini/IniBackend.h
+++ b/src/Backends/Ini/IniBackend.h
@@ -33,7 +33,7 @@ class IniBackend final : public BackendBase
 {
   public:
     /// Read and parse INI file
-    IniBackend(const std::string& filePath);
+    IniBackend(const std::string& file, bool isStream = false);
 
     /// Default destructor
     virtual ~IniBackend() = default;

--- a/src/Backends/Json/JsonBackend.cxx
+++ b/src/Backends/Json/JsonBackend.cxx
@@ -23,18 +23,24 @@ namespace configuration
 namespace backends
 {
 
-JsonBackend::JsonBackend(const std::string& filePath)
+JsonBackend::JsonBackend(const std::string& file)
 {
-  if (filePath.length() == 0) {
+  if (file.length() == 0) {
     throw std::runtime_error("JSON filepath is empty");
   }
-  mPath = filePath;
+  mPath = file;
 }
 
-void JsonBackend::readJsonFile()
+void JsonBackend::readJsonFile(bool isStream)
 {
   try {
-    boost::property_tree::read_json(mPath, mTree);
+    if (isStream) {
+      std::istringstream ss; 
+      ss.str(mPath);
+      boost::property_tree::read_json(ss, mTree);
+    } else {
+      boost::property_tree::read_json(mPath, mTree);
+    }
   }
   catch (const boost::property_tree::ptree_error &error) {
      throw std::runtime_error("Unable to read JSON file: " + mPath);

--- a/src/Backends/Json/JsonBackend.h
+++ b/src/Backends/Json/JsonBackend.h
@@ -31,8 +31,8 @@ class JsonBackend final : public BackendBase
 {
   public:
     /// Opens and parses JSON file
-    /// \param filePath A file path to JSON file
-    JsonBackend(const std::string& filePath);
+    /// \param file A file path to JSON file or JSON data
+    JsonBackend(const std::string& file);
 
     /// Default destructor
     virtual ~JsonBackend() = default;
@@ -41,7 +41,7 @@ class JsonBackend final : public BackendBase
     virtual boost::optional<std::string> getString(const std::string& path) override;
     virtual boost::property_tree::ptree getRecursive(const std::string& path) override;
     virtual KeyValueMap getRecursiveMap(const std::string& path) override;
-    void readJsonFile();
+    void readJsonFile(bool isStream = false);
   private:
     /// Parsed JSON file
     boost::property_tree::ptree mTree;

--- a/test/TestIni.cxx
+++ b/test/TestIni.cxx
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include "Configuration/ConfigurationFactory.h"
 #include "Configuration/ConfigurationInterface.h"
+#include "../src/Backends/Ini/IniBackend.h"
 
 #define BOOST_TEST_MODULE IniBackend
 #define BOOST_TEST_MAIN
@@ -91,6 +92,18 @@ BOOST_AUTO_TEST_CASE(IniFileTestPrefix)
   BOOST_CHECK_EQUAL(conf->get<int>("key_int"), 123);
   BOOST_CHECK_EQUAL(conf->get<double>("key_float"), 4.56);
   BOOST_CHECK_EQUAL(conf->get<std::string>("key_string"), "hello");
+}
+
+BOOST_AUTO_TEST_CASE(IniFileUseStream)
+{
+  std::string iniContent = "key=value\n"
+        "[section]\n"
+        "key_int=123\n"
+        "key_float=4.56\n"
+        "key_string=hello\n";
+  auto conf = std::make_unique<backends::IniBackend>(iniContent, true);
+  BOOST_CHECK(conf->get<std::string>("key") == "value");
+  BOOST_CHECK(conf->get<int>("section.key_int") == 123);
 }
 
 } // Anonymous namespace


### PR DESCRIPTION
You can read JSON or INI files from Consul and use exactly same interface as it'd be a file on the disk.

The following backends are added:
- `consul-ini`: Requires full path to Consul value where INI is stored
- `consul-json`: Requires full path to Consul value where JSON is stored